### PR TITLE
Handle large image case

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,26 @@ export function activate(ctx: vscode.ExtensionContext) {
           if (!match) {
 						return;
           }
+
+          if (match[0].length > 200000) {
+            const panel = vscode.window.createWebviewPanel(
+              'base64Image',
+              'Image Preview',
+              vscode.ViewColumn.One,
+              { enableScripts: false }
+            );
+	    panel.webview.html = `<img src="${match[0]}" style="max-width: 100%; max-height: 100vh; object-fit: contain;">`;
+
+            // close the panel when it's no longer focused
+            panel.onDidChangeViewState(e => {
+              if (panel.visible === false) {
+                panel.dispose(); 
+              }
+            });
+
+	    return;
+          }
+		
           return new vscode.Hover(
             new vscode.MarkdownString(`![image](${match[0]})`)
           );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,7 @@ export function activate(ctx: vscode.ExtensionContext) {
 						return;
           }
 
-          if (match[0].length > 200000) {
+          if (match[0].length > 100000) {
             const panel = vscode.window.createWebviewPanel(
               'base64Image',
               'Image Preview',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,25 @@
 import * as vscode from "vscode";
 
 export function activate(ctx: vscode.ExtensionContext) {
+  let base64image = '';
+
+  vscode.commands.registerCommand('openLargeImage', () => {
+    const panel = vscode.window.createWebviewPanel(
+      'base64Image', 
+      'Image Preview', 
+      vscode.ViewColumn.One, 
+      { enableScripts: false }
+    );
+    panel.webview.html = `<img src="${base64image}" style="max-width: 100%; max-height: 100vh; object-fit: contain;">`;
+
+    // close the panel when it's no longer focused
+    panel.onDidChangeViewState(e => {
+      if (panel.visible === false) {
+        panel.dispose();
+      }
+    });
+  });
+
   ctx.subscriptions.push(
     vscode.languages.registerHoverProvider(
       "*",
@@ -22,22 +41,10 @@ export function activate(ctx: vscode.ExtensionContext) {
           }
 
           if (match[0].length > 100000) {
-            const panel = vscode.window.createWebviewPanel(
-              'base64Image',
-              'Image Preview',
-              vscode.ViewColumn.One,
-              { enableScripts: false }
-            );
-	    panel.webview.html = `<img src="${match[0]}" style="max-width: 100%; max-height: 100vh; object-fit: contain;">`;
-
-            // close the panel when it's no longer focused
-            panel.onDidChangeViewState(e => {
-              if (panel.visible === false) {
-                panel.dispose(); 
-              }
-            });
-
-	    return;
+            base64image = match[0];
+            const hoverMessage = new vscode.MarkdownString(`[Open Image in New Tab](command:openLargeImage)`);
+            hoverMessage.isTrusted = true;
+            return new vscode.Hover(hoverMessage);
           }
 		
           return new vscode.Hover(


### PR DESCRIPTION
### Before:

Big images don't render:

![CleanShot 2024-02-14 at 15 26 12@2x](https://github.com/NateScarlet/base64-image-preview/assets/8968171/a3bc0870-b649-4639-8e23-1f2a1f6f10eb)

### After:

Big images render in a new tab, and the tab auto-closes when you focus away:

![CleanShot 2024-02-15 at 22 10 37@2x](https://github.com/NateScarlet/base64-image-preview/assets/8968171/bb620290-3d61-4153-9156-6bd4c0b398c8)


![CleanShot 2024-02-14 at 15 30 33@2x](https://github.com/NateScarlet/base64-image-preview/assets/8968171/87f71b9c-d2e3-4ab4-9830-ae84e6da32f4)

---

Feel free to close this PR if you think it might be jarring to automatically open a new tab.